### PR TITLE
Update deprecated typedefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ A tool for controlling firebase with Javascript for everyone.
 
 ## Enviroment
 
-Haxe < 3.4.7
+Tested with:
 
-JavaScript Firebase SDK < 6.4.0
+Haxe < 4.0
+
+JavaScript Firebase SDK < 8.10
 
 ## Example
 

--- a/firebase/Observer.hx
+++ b/firebase/Observer.hx
@@ -1,6 +1,6 @@
 package firebase;
 
-import js.Error;
+import js.lib.Error;
 
 extern interface Observer {
 

--- a/firebase/User.hx
+++ b/firebase/User.hx
@@ -1,6 +1,6 @@
 package firebase;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.auth.ApplicationVerifier;
 import firebase.auth.Auth.ActionCodeSettings;
 import firebase.auth.Auth.UserCredential;

--- a/firebase/app/App.hx
+++ b/firebase/app/App.hx
@@ -1,6 +1,6 @@
 package firebase.app;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.Firebase;
 import firebase.auth.Auth;
 import firebase.database.Database;

--- a/firebase/auth/ApplicationVerifier.hx
+++ b/firebase/auth/ApplicationVerifier.hx
@@ -1,6 +1,6 @@
 package firebase.auth;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.auth.RecaptchaVerifier;
 
 @:native('firebase.auth.ApplicationVerifier')

--- a/firebase/auth/Auth.hx
+++ b/firebase/auth/Auth.hx
@@ -1,6 +1,6 @@
 package firebase.auth;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.app.App;
 import firebase.auth.ApplicationVerifier;
 import firebase.auth.AuthSettings;

--- a/firebase/auth/ConfirmationResult.hx
+++ b/firebase/auth/ConfirmationResult.hx
@@ -1,6 +1,6 @@
 package firebase.auth;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.auth.Auth.UserCredential;
 
 @:native('firebase.auth.ConfirmationResult')

--- a/firebase/auth/OAuthCredential.hx
+++ b/firebase/auth/OAuthCredential.hx
@@ -1,6 +1,6 @@
 package firebase.auth;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.auth.Auth.UserCredential;
 import firebase.auth.AuthCredential;
 

--- a/firebase/auth/PhoneAuthProvider.hx
+++ b/firebase/auth/PhoneAuthProvider.hx
@@ -1,6 +1,6 @@
 package firebase.auth;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.auth.ApplicationVerifier;
 import firebase.auth.Auth;
 import firebase.auth.AuthCredential;

--- a/firebase/auth/RecaptchaVerifier.hx
+++ b/firebase/auth/RecaptchaVerifier.hx
@@ -1,6 +1,6 @@
 package firebase.auth;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.app.App;
 
 @:native('firebase.auth.RecaptchaVerifier')

--- a/firebase/database/OnDisconnect.hx
+++ b/firebase/database/OnDisconnect.hx
@@ -1,6 +1,6 @@
 package firebase.database;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.auth.Error;
 
 @:native('firebase.database.OnDisconnect')

--- a/firebase/database/Reference.hx
+++ b/firebase/database/Reference.hx
@@ -1,6 +1,6 @@
 package firebase.database;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.auth.Error;
 import firebase.database.DataSnapshot;
 import firebase.database.OnDisconnect;

--- a/firebase/database/ThenableReference.hx
+++ b/firebase/database/ThenableReference.hx
@@ -1,6 +1,6 @@
 package firebase.database;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.database.Reference;
 
 @:native('firebase.database.ThenableReference')

--- a/firebase/firestore/Blob.hx
+++ b/firebase/firestore/Blob.hx
@@ -1,6 +1,6 @@
 package firebase.firestore;
 
-import js.html.Uint8Array;
+import js.lib.Uint8Array;
 
 @:native('firebase.firestore.Blob')
 extern class Blob {

--- a/firebase/firestore/CollectionReference.hx
+++ b/firebase/firestore/CollectionReference.hx
@@ -1,6 +1,6 @@
 package firebase.firestore;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.firestore.DocumentReference;
 import firebase.firestore.Firestore.DocumentData;
 import firebase.firestore.Query;

--- a/firebase/firestore/DocumentReference.hx
+++ b/firebase/firestore/DocumentReference.hx
@@ -1,6 +1,6 @@
 package firebase.firestore;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.firestore.CollectionReference;
 import firebase.firestore.DocumentSnapshot;
 import firebase.firestore.FieldPath;

--- a/firebase/firestore/Firestore.hx
+++ b/firebase/firestore/Firestore.hx
@@ -1,6 +1,6 @@
 package firebase.firestore;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.app.App;
 import firebase.firestore.CollectionReference;
 import firebase.firestore.DocumentReference;

--- a/firebase/firestore/Query.hx
+++ b/firebase/firestore/Query.hx
@@ -1,6 +1,6 @@
 package firebase.firestore;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.firestore.DocumentSnapshot;
 import firebase.firestore.Firestore.WhereFilterOp;
 import firebase.firestore.Firestore.OrderByDirection;

--- a/firebase/firestore/Transaction.hx
+++ b/firebase/firestore/Transaction.hx
@@ -1,6 +1,6 @@
 package firebase.firestore;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.firestore.DocumentReference;
 import firebase.firestore.DocumentSnapshot;
 import firebase.firestore.FieldPath;

--- a/firebase/firestore/WriteBatch.hx
+++ b/firebase/firestore/WriteBatch.hx
@@ -1,6 +1,6 @@
 package firebase.firestore;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.firestore.DocumentReference;
 import firebase.firestore.FieldPath;
 import firebase.firestore.Firestore.DocumentData;

--- a/firebase/functions/Functions.hx
+++ b/firebase/functions/Functions.hx
@@ -1,6 +1,6 @@
 package firebase.functions;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.functions.HttpsCallable;
 import firebase.functions.HttpsCallableOptions;
 

--- a/firebase/functions/HttpsCallable.hx
+++ b/firebase/functions/HttpsCallable.hx
@@ -1,6 +1,6 @@
 package firebase.functions;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.functions.HttpsCallableResult;
 
 @:native('firebase.functions.HttpsCallable')

--- a/firebase/functions/HttpsError.hx
+++ b/firebase/functions/HttpsError.hx
@@ -1,6 +1,6 @@
 package firebase.functions;
 
-import js.Error;
+import js.lib.Error;
 import firebase.functions.Functions.FunctionsErrorCode;
 
 @:native('firebase.functions.HttpsError')

--- a/firebase/installations/Installations.hx
+++ b/firebase/installations/Installations.hx
@@ -1,6 +1,6 @@
 package firebase.installations;
 
-import js.Promise;
+import js.lib.Promise;
 
 @:native('firebase.installations.Installations')
 extern class Installations {

--- a/firebase/messaging/Messaging.hx
+++ b/firebase/messaging/Messaging.hx
@@ -1,7 +1,7 @@
 package firebase.messaging;
 
 import js.html.ServiceWorkerRegistration;
-import js.Promise;
+import js.lib.Promise;
 import firebase.CompleteFn;
 import firebase.ErrorFn;
 import firebase.NextFn;

--- a/firebase/storage/Reference.hx
+++ b/firebase/storage/Reference.hx
@@ -1,9 +1,9 @@
 package firebase.storage;
 
 import js.lib.Promise;
-import js.html.ArrayBuffer;
+import js.lib.ArrayBuffer;
 import js.html.Blob;
-import js.html.Uint8Array;
+import js.lib.Uint8Array;
 import firebase.storage.ListOptions;
 import firebase.storage.ListResult;
 import firebase.storage.SettableMetadata;

--- a/firebase/storage/Reference.hx
+++ b/firebase/storage/Reference.hx
@@ -1,6 +1,6 @@
 package firebase.storage;
 
-import js.Promise;
+import js.lib.Promise;
 import js.html.ArrayBuffer;
 import js.html.Blob;
 import js.html.Uint8Array;

--- a/firebase/storage/Storage.hx
+++ b/firebase/storage/Storage.hx
@@ -1,6 +1,6 @@
 package firebase.storage;
 
-import js.Promise;
+import js.lib.Promise;
 import firebase.app.App;
 import firebase.storage.Reference;
 

--- a/firebase/storage/UploadTask.hx
+++ b/firebase/storage/UploadTask.hx
@@ -1,7 +1,7 @@
 package firebase.storage;
 
 import js.Error;
-import js.Promise;
+import js.lib.Promise;
 import firebase.storage.Storage.TaskEvent;
 import firebase.storage.UploadTaskSnapshot;
 

--- a/firebase/storage/UploadTask.hx
+++ b/firebase/storage/UploadTask.hx
@@ -1,6 +1,6 @@
 package firebase.storage;
 
-import js.Error;
+import js.lib.Error;
 import js.lib.Promise;
 import firebase.storage.Storage.TaskEvent;
 import firebase.storage.UploadTaskSnapshot;


### PR DESCRIPTION
Fixes https://github.com/okawa-h/js-firebase-extern/issues/1

This removes the warnings for me. I'm using Firestore and this works with Haxe 4 and the most recent Firebase (8.10).

I think that it's safe to make those typedef changes, but I don't know if there needs more testing to say that Haxe 4 and Firebase 8.10 is officially supported.