### PR TITLE
Fix FieldValue vararg signatures

### DIFF
--- a/firebase/firestore/FieldValue.hx
+++ b/firebase/firestore/FieldValue.hx
@@ -1,5 +1,7 @@
 package firebase.firestore;
 
+import haxe.extern.Rest;
+
 @:native('firebase.firestore.FieldValue')
 extern class FieldValue {
 
@@ -7,8 +9,8 @@ extern class FieldValue {
 
 	public function isEqual(other:FieldValue):Bool;
 
-	public static function arrayRemove(elements:Array<Dynamic>):FieldValue;
-	public static function arrayUnion(elements:Array<Dynamic>):FieldValue;
+	public static function arrayRemove(elements:Rest<Dynamic>):FieldValue;
+	public static function arrayUnion(elements:Rest<Dynamic>):FieldValue;
 	public static function delete():FieldValue;
 	public static function increment(n:Int):FieldValue;
 	public static function serverTimestamp():FieldValue;


### PR DESCRIPTION
Hey, I noticed I wasn't able to use `arrayUnion`, because it was interpreting the array argument as an nested array (instead of multiple arguments).

I'm not very familiar with Haxe extern definitions, but using `Rest` seemed the more correct way here (worked for me). Not sure if there was an API change for Firebase.